### PR TITLE
docs: add deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,39 @@ are parsed at runtime by the backend via PyYAML.
 
 ## Environment variables
 
-The backend reads optional settings from a `.env` file in the `backend` directory. To enable the explanation features, provide an OpenRouter API key and model name, for example:
+Set the following variables in your deployment environment or in a `.env` file.  Hosting platforms such as Vercel, Render or Heroku expose dashboards for managing these values.
 
-```
-OPENROUTER_API_KEY=your-openrouter-key
-OPENROUTER_MODEL=openai/o4-mini
-```
+| Variable | Purpose |
+| -------- | ------- |
+| `OPENROUTER_API_KEY` | API key for optional LLM explanations. |
+| `OPENROUTER_MODEL` | (Optional) OpenRouter model. Defaults to `openai/o4-mini`. |
+| `TELEGRAM_BOT_TOKEN` | Token for the Telegram bot. |
+| `WEBHOOK_URL` | Public URL for webhook mode. Leave unset when using polling. |
+| `ALLOWED_CORS_ORIGINS` | Comma‑separated list of origins allowed by the backend. |
+| `VITE_API_PREFIX` | Frontend build‑time URL to the backend API (e.g. `https://your-backend.example.com/v1`). |
 
-`OPENROUTER_MODEL` defaults to `openai/o4-mini` if left unset.
+The backend automatically loads environment variables from a `.env` file in the `backend/` directory.  The frontend uses variables prefixed with `VITE_` during its build step.
+
+## Deployment
+
+### Frontend (Vercel)
+
+1. Create a new Vercel project and set the **root directory** to `frontend`.
+2. Use `npm run build` as the build command and `dist` as the output directory.
+3. Define the `VITE_API_PREFIX` environment variable pointing to your deployed backend URL.
+4. Deploy and note the resulting public URL.
+5. In Telegram's BotFather, configure the mini app **App URL** to the Vercel deployment URL.
+
+### Backend and Bot (Render/Heroku)
+
+1. Create a new web service from this repository.  The provided `Procfile` starts the FastAPI app with Gunicorn.
+2. Configure environment variables such as `TELEGRAM_BOT_TOKEN`, `OPENROUTER_API_KEY`, and `ALLOWED_CORS_ORIGINS`.
+3. For **webhook** operation:
+   - Set `WEBHOOK_URL` to your public backend URL.
+   - Register the webhook with Telegram using `https://api.telegram.org/bot<token>/setWebhook?url=<WEBHOOK_URL>`.
+4. For **polling** operation:
+   - Add a worker process that runs the polling script in the `bot/` directory.
+5. After deployment, verify the API with `curl https://<backend-url>/health` and ensure your frontend origin is included in `ALLOWED_CORS_ORIGINS` for CORS.
 
 ## Strategy report
 


### PR DESCRIPTION
## Summary
- document required environment variables
- add deployment steps for Vercel, Render and Heroku

## Testing
- `poetry run pytest` (fails: AttributeError Config)
- `npm test` (fails: jest-environment-jsdom cannot be found)


------
https://chatgpt.com/codex/tasks/task_e_68a9285c96308326a4748a21739a9994