### PR TITLE
Add python-telegram-bot dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pyyaml>=6.0.0
 redis>=5.0.0
 email-validator>=2.0.0
 python-dateutil>=2.9.0
+python-telegram-bot>=21.0


### PR DESCRIPTION
## Summary
- add python-telegram-bot package to requirements

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement python-telegram-bot>=21.0: Tunnel connection failed: 403 Forbidden)
- `pytest backend/tests` (fails: AttributeError: Config)


------
https://chatgpt.com/codex/tasks/task_e_68a9f5fabcb88326b2b5087144761d07