### PR TITLE
Add python-telegram-bot dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pyyaml>=6.0.0
 redis>=5.0.0
 email-validator>=2.0.0
 python-dateutil>=2.9.0
+python-telegram-bot>=21.0


### PR DESCRIPTION
## Summary
- add python-telegram-bot package to Python dependencies

## Testing
- `pip install -r requirements.txt` (fails: Could not connect to proxy)
- `pytest` (fails: 11 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68aa753939848326891cd11f1ee4c4c4